### PR TITLE
Add option to return a mp4 with audio only

### DIFF
--- a/server.js
+++ b/server.js
@@ -296,11 +296,12 @@ async function callYitter(data) {
   return new Promise((resolve, reject) => {
     console.log(`callYitter data:`, data);
     const videoId = data.videoId;
+    const audioOnly = data?.audioOnly;
 
     console.log(`callYitter videoId:${videoId}`)
-
+    console.log(`callYitter audioOnly:${audioOnly}`)
     // Construct the youtube-dl command
-    const command = `youtube-dl -g -f mp4 --verbose --force-generic-extractor https://www.youtube.com/watch?v=${videoId}`;
+    const command = `youtube-dl -g${audioOnly ? ' --extract-audio' : ''} -f mp4 --verbose --force-generic-extractor https://www.youtube.com/watch?v=${videoId}`;
 
     // Execute the youtube-dl command
     exec(command, (error, stdout, stderr) => {


### PR DESCRIPTION
By default the normal mp4 with video will be returned, if audioOnly is True the mp4 will be audio only.